### PR TITLE
feat: disable workspace trust when running tests

### DIFF
--- a/packages/vscode-test-cli/README.md
+++ b/packages/vscode-test-cli/README.md
@@ -2,7 +2,7 @@
 
 This package helps you run the tests for your VS Code extension in a VS Code environment by configuring the extension parameters in a configuration file and running the tests from the `scripts` section of the `package.json`, using a command line interface.
 
-This package uses the [`vscode-test`](https://github.com/microsoft/vscode-test) package for running the tests according to the configuration.
+This package uses the [`@vscode/test-electron`](https://github.com/microsoft/vscode-test) package for running the tests according to the configuration.
 
 Download and installation instructions can be found under the "Usage" section.
 

--- a/packages/vscode-test-cli/package.json
+++ b/packages/vscode-test-cli/package.json
@@ -39,7 +39,7 @@
     "lodash": "4.17.21",
     "mocha": "8.2.1",
     "nyc": "15.1.0",
-    "vscode-test": "1.5.2",
+    "@vscode/test-electron": "1.6.2",
     "yargs": "16.2.0"
   }
 }

--- a/packages/vscode-test-cli/src/vscode-tests.ts
+++ b/packages/vscode-test-cli/src/vscode-tests.ts
@@ -3,7 +3,7 @@ import {
   resolveCliPathFromVSCodeExecutablePath,
   downloadAndUnzipVSCode,
   runTests,
-} from "vscode-test";
+} from "@vscode/test-electron";
 import { spawnSync } from "child_process";
 import { readdir, writeJson, unlink, pathExists, mkdirs, stat } from "fs-extra";
 import { map, isArray, filter, isEmpty } from "lodash";

--- a/packages/vscode-test-cli/test/vscode-tests.spec.ts
+++ b/packages/vscode-test-cli/test/vscode-tests.spec.ts
@@ -24,7 +24,7 @@ import { PathRemover, SinonStubType } from "./test-utils";
 
 use(chaiAsPromised);
 type VSCodeTestsType = typeof import("../src/vscode-tests");
-type VSCodeTestLibType = typeof import("vscode-test");
+type VSCodeTestLibType = typeof import("@vscode/test-electron");
 
 describe("vscode-tests", () => {
   const pathsRemover = new PathRemover();
@@ -568,7 +568,7 @@ describe("vscode-tests", () => {
       runTestsStub = sinon.stub();
       spawnSyncStub = sinon.stub();
       runVSCodeTests = (proxyquire(require.resolve("../src/vscode-tests"), {
-        "vscode-test": {
+        "@vscode/test-electron": {
           resolveCliPathFromVSCodeExecutablePath: resolveCliPathFromVSCodeExecutablePathStub,
           downloadAndUnzipVSCode: downloadAndUnzipVSCodeStub,
           runTests: runTestsStub,
@@ -1405,7 +1405,7 @@ describe("vscode-tests", () => {
         runTestsFromCommandLineInner = (proxyquire(
           require.resolve("../src/vscode-tests"),
           {
-            "vscode-test": {
+            "@vscode/test-electron": {
               resolveCliPathFromVSCodeExecutablePath: resolveCliPathFromVSCodeExecutablePathStub,
               downloadAndUnzipVSCode: downloadAndUnzipVSCodeStub,
               runTests: runTestsStub,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,6 +1478,16 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
+"@vscode/test-electron@1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@vscode/test-electron/-/test-electron-1.6.2.tgz#f639cab19a0013949015079dcfd2ff0c1aa88a1b"
+  integrity sha512-W01ajJEMx6223Y7J5yaajGjVs1QfW3YGkkOJHVKfAMEqNB1ZHN9wCcViehv5ZwVSSJnjhu6lYEYgwBdHtCxqhQ==
+  dependencies:
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    rimraf "^3.0.2"
+    unzipper "^0.10.11"
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -4646,12 +4656,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@4.17.20:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
-lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.7.0:
+lodash@4.17.21, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -7308,16 +7313,6 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
-
-vscode-test@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/vscode-test/-/vscode-test-1.5.2.tgz#d9ec3cab1815afae1d7d81923e3c685d13d32303"
-  integrity sha512-x9PVfKxF6EInH9iSFGQi0V8H5zIW1fC7RAer6yNQR6sy3WyOwlWkuT3I+wf75xW/cO53hxMi1aj/EvqQfDFOAg==
-  dependencies:
-    http-proxy-agent "^4.0.1"
-    https-proxy-agent "^5.0.0"
-    rimraf "^3.0.2"
-    unzipper "^0.10.11"
 
 wcwidth@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This is implemented in package `@vscode/test-electron` version 1.6.2, which is the newest version of package `vscode-test`.

Tests run on test workspaces, which are defined by the extension developer, therefore they should always be trusted.